### PR TITLE
Add Markdown home page

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "prosemirror-markdown": "^1.13.2",
     "react": "^18",
     "react-dom": "^18",
-    "react-markdown": "^10.1.0"
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^3.0.1"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.7",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { useState } from 'react'
+import { Textarea } from '@/components/ui/textarea'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+
+export default function Home() {
+  const [value, setValue] = useState('')
+
+  return (
+    <main className="flex min-h-dvh flex-col items-center p-6 lg:p-10">
+      <div className="w-full max-w-3xl space-y-6">
+        <Textarea
+          value={value}
+          onChange={(e) => setValue(e.currentTarget.value)}
+          className="h-40"
+          placeholder="Enter markdown here..."
+        />
+        <div className="rounded-lg border border-zinc-950/10 bg-white p-6 shadow-sm dark:border-white/10 dark:bg-zinc-900">
+          <ReactMarkdown remarkPlugins={[remarkGfm]} className="space-y-4">
+            {value}
+          </ReactMarkdown>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3619,6 +3619,16 @@ react-markdown@^10.1.0:
     unist-util-visit "^5.0.0"
     vfile "^6.0.0"
 
+remark-gfm@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/remark-gfm/-/remark-gfm-3.0.1.tgz#0b180f095e3036545e9dddac0e8df3fa5cfee54f"
+  integrity sha512-lEFDoi2PICJyNrACFOfDD3JlLkuSbOa5Wd8EPt06HUdptv8Gn0bxYTdbU/XXQ3swAPkEaGxxPN9cbnMHvVu1Ig==
+  dependencies:
+    "@types/mdast" "^3.0.0"
+    mdast-util-gfm "^2.0.0"
+    micromark-extension-gfm "^2.0.0"
+    unified "^10.0.0"
+
 react@^18:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react/-/react-18.3.1.tgz#49ab892009c53933625bd16b2533fc754cab2891"


### PR DESCRIPTION
## Summary
- add a basic home page using the existing UI components
- show markdown rendering with `react-markdown` and `remark-gfm`
- declare the new `remark-gfm` dependency

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68511f146de4833182318c3baabaff1d