### PR TITLE
Fix remark plugin usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,18 @@ Lire is a simple tool for reading French text. It displays pre-written passages 
 
 ## Getting Started
 
-Install dependencies and start the development server:
+Install dependencies (which includes the `remark-breaks` plugin) and start the development server:
 
 ```bash
 npm install
 npm run dev
+```
+
+If the build fails with `Module not found: Can't resolve 'remark-breaks'`, install the
+plugin manually:
+
+```bash
+npm install remark-breaks
 ```
 
 Then open [http://localhost:3000](http://localhost:3000) to view the application.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-markdown": "^10.1.0",
-    "remark-gfm": "^4.0.1"
+    "remark-breaks": "^4.0.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.10",

--- a/src/app/(app)/orders/[id]/page.tsx
+++ b/src/app/(app)/orders/[id]/page.tsx
@@ -11,16 +11,18 @@ import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import { RefundOrder } from './refund'
 
-export async function generateMetadata({ params }: { params: { id: string } }): Promise<Metadata> {
-  let order = await getOrder(params.id)
+export async function generateMetadata({ params }: { params: Promise<{ id: string }> }): Promise<Metadata> {
+  let { id } = await params
+  let order = await getOrder(id)
 
   return {
     title: order && `Order #${order.id}`,
   }
 }
 
-export default async function Order({ params }: { params: { id: string } }) {
-  let order = await getOrder(params.id)
+export default async function Order({ params }: { params: Promise<{ id: string }> }) {
+  let { id } = await params
+  let order = await getOrder(id)
 
   if (!order) {
     notFound()

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { Dialog, DialogActions, DialogBody, DialogDescription, DialogTitle } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import ReactMarkdown from 'react-markdown'
-import remarkGfm from 'remark-gfm'
+import remarkBreaks from 'remark-breaks'
 
 export default function Home() {
   const [value, setValue] = useState('')
@@ -21,10 +21,10 @@ export default function Home() {
           placeholder="Enter markdown here..."
         />
         <div
-          className="rounded-lg border border-zinc-950/10 bg-white p-6 shadow-sm dark:border-white/10 dark:bg-zinc-900"
+          className="rounded-lg border border-zinc-950/10 bg-white p-6 shadow-sm dark:border-white/10 dark:bg-zinc-900 space-y-4"
           onClick={() => setIsOpen(true)}
         >
-          <ReactMarkdown remarkPlugins={[remarkGfm]} className="space-y-4">
+          <ReactMarkdown remarkPlugins={[remarkBreaks]}>
             {value}
           </ReactMarkdown>
         </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3469,17 +3469,13 @@ regexp.prototype.flags@^1.5.3, regexp.prototype.flags@^1.5.4:
     gopd "^1.2.0"
     set-function-name "^2.0.2"
 
-remark-gfm@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/remark-gfm/-/remark-gfm-4.0.1.tgz#33227b2a74397670d357bf05c098eaf8513f0d6b"
-  integrity sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==
+remark-breaks@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/remark-breaks/-/remark-breaks-4.0.0.tgz#dcc19a2891733906f3b97eaa8acb8621e8da8852"
+  integrity sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==
   dependencies:
     "@types/mdast" "^4.0.0"
-    mdast-util-gfm "^3.0.0"
-    micromark-extension-gfm "^3.0.0"
-    remark-parse "^11.0.0"
-    remark-stringify "^11.0.0"
-    unified "^11.0.0"
+    mdast-util-newline-to-break "^2.0.0"
 
 remark-parse@^11.0.0:
   version "11.0.0"


### PR DESCRIPTION
## Summary
- switch from remark-gfm to remark-breaks
- update README for new plugin
- fix build error in orders page by awaiting params
- drop deprecated ReactMarkdown className prop

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68512df8caf483318e1cce9e352bdccf