### PR TITLE
Fix sass import and markdown class usage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -57,7 +57,9 @@ export default function Home() {
           placeholder="Enter markdown here..."
         />
         <div className="space-y-4 rounded-lg border border-zinc-950/10 bg-white p-6 shadow-sm dark:border-white/10 dark:bg-zinc-900">
-          <ReactMarkdown className="prose dark:prose-invert">{value}</ReactMarkdown>
+          <div className="prose dark:prose-invert">
+            <ReactMarkdown>{value}</ReactMarkdown>
+          </div>
         </div>
       </div>
     </SidebarLayout>

--- a/src/styles/tailwind.scss
+++ b/src/styles/tailwind.scss
@@ -1,8 +1,9 @@
-@import '@/styles/_variables.scss';
-@import '@/styles/_keyframe-animations.scss';
+@use '@/styles/_variables.scss' as *;
+@use '@/styles/_keyframe-animations.scss' as *;
 
-// Tailwind core
-@import 'tailwindcss';
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 
 


### PR DESCRIPTION
## Summary
- replace deprecated `@import` uses in Tailwind SCSS file
- update markdown rendering to avoid deprecated `className` prop

## Testing
- `node tests/appLaunch.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6851788f469083319b01ec490a5215da